### PR TITLE
Add golang & rustfmt

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,9 +8,11 @@ RUN dnf install -y \
         gcc \
         gcc-c++ \
         git \
+        golang \
         jq \
         just \
         openssl-devel \
         podman \
+        rustfmt \
     && \
     dnf clean all


### PR DESCRIPTION
for new Go-based CRDs; Go to build the YAML using controller-gen and rustfmt to clean up kopium's output which builds Rust from YAML.