### PR TITLE
Add OpenSSL dependencies

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,5 +14,7 @@ RUN dnf install -y \
         openssl-devel \
         podman \
         rustfmt \
+        perl-FindBin \
+        perl-core \
     && \
     dnf clean all


### PR DESCRIPTION
After updating the `openssl-sys` dependency from `openssl-sys 0.9.112` to `openssl-sys 0.9.113` in [PR#248](https://github.com/trusted-execution-clusters/operator/pull/248). This error occurred
```
cargo:warning=configuring OpenSSL build: 'perl' reported failure with exit status: 2
  cargo:warning=openssl-src: failed to build OpenSSL from source

  --- stderr
  Can't locate FindBin.pm in @INC (you may need to install the FindBin module) (@INC entries checked: /usr/local/lib64/perl5/5.42 /usr/local/share/perl5/5.42 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ./Configure line 15.
  BEGIN failed--compilation aborted at ./Configure line 15.
```
This PR solves the issue